### PR TITLE
sec: bump required phpunit to version 5.6.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "twig/twig": "3.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.5.*",
+        "phpunit/phpunit": "5.6.3",
         "phpmd/phpmd": "@stable",
         "squizlabs/php_codesniffer": "2.*"
     }


### PR DESCRIPTION
fixes CVE-2017-9841 witch allows remote attackers to execute arbitrary PHP code via HTTP POST